### PR TITLE
Hot fix - Client ID is now needed with every request to the Kraken API

### DIFF
--- a/src/pytwitcherapi/session.py
+++ b/src/pytwitcherapi/session.py
@@ -229,6 +229,7 @@ class TwitchSession(OAuthSession):
         url = TWITCH_KRAKENURL + endpoint
         headers = kwargs.setdefault('headers', {})
         headers['Accept'] = TWITCH_HEADER_ACCEPT
+        headers['Client-ID'] = CLIENT_ID # https://github.com/justintv/Twitch-API#rate-limits
         return self.request(method, url, **kwargs)
 
     def usher_request(self, method, endpoint, **kwargs):


### PR DESCRIPTION
You can read (a little bit) more about this issue here :
https://github.com/justintv/Twitch-API/issues/609

Since today (Sept., 16th 2016) all calls to the Kraken API require you
to send a valid client id.

This is a hotfix, using the client id provided by pytwitcher. Maybe a
better implementation would be to allow the user to provide it’s own
client id.

At least, now this library is functional again for those using it in
production !